### PR TITLE
Add classes to body tag for child theming

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -7,7 +7,7 @@
     {include file="$template/includes/head.tpl"}
     {$headoutput}
 </head>
-<body class="primary-bg-color" data-phone-cc-input="{$phoneNumberInputStyle}">
+<body class="primary-bg-color{if $loggedin} loggedin{/if} {$templatefile} {$filename}" data-phone-cc-input="{$phoneNumberInputStyle}">
 
     {$headeroutput}
 


### PR DESCRIPTION
It can be super handy for child theming to be able to target specific pages and conditions. These classes help make that happen.