### PR TITLE
Ensure category count doesn't wrap below titles

### DIFF
--- a/knowledgebasecat.tpl
+++ b/knowledgebasecat.tpl
@@ -16,6 +16,9 @@
                 <div class="card kb-category mb-4">
                     <a href="{routePath('knowledgebase-category-view', {$category.id}, {$category.urlfriendlyname})}" class="card-body" data-id="{$category.id}">
                         <span class="h5 m-0">
+                            <span class="badge badge-info float-right">
+                                {lang key="knowledgebase.numArticle{if $category.numarticles != 1}s{/if}" num=$category.numarticles}
+                            </span>
                             <i class="fal fa-folder fa-fw"></i>
                             {$category.name}
                             {if $category.editLink}
@@ -23,9 +26,6 @@
                                     {lang key="edit"}
                                 </button>
                             {/if}
-                            <span class="badge badge-info float-right">
-                                {lang key="knowledgebase.numArticle{if $category.numarticles != 1}s{/if}" num=$category.numarticles}
-                            </span>
                         </span>
                         <p class="m-0 text-muted"><small>{$category.description}</small></p>
                     </a>


### PR DESCRIPTION
When the title of a KB article is longer than the width of the card element (minus the badge width), the category count badge drops below the title. This change ensures it always floats above the title and therefore remains in the upper right corner of the card. Now rather than the count badge wrapping, the title wraps, which is far better.