### PR TITLE
d-inline-block class causes poor display issues

### DIFF
--- a/includes/sidebar.tpl
+++ b/includes/sidebar.tpl
@@ -15,7 +15,7 @@
                 </div>
             {/if}
             {if $item->hasChildren()}
-                <div class="list-group list-group-flush d-inline-block d-md-flex{if $item->getChildrenAttribute('class')} {$item->getChildrenAttribute('class')}{/if}" role="tablist">
+                <div class="list-group list-group-flush d-md-flex{if $item->getChildrenAttribute('class')} {$item->getChildrenAttribute('class')}{/if}" role="tablist">
                     {foreach $item->getChildren() as $childItem}
                         {if $childItem->getUri()}
                             <a menuItemName="{$childItem->getName()}" href="{$childItem->getUri()}" class="list-group-item list-group-item-action{if $childItem->isDisabled()} disabled{/if}{if $childItem->getClass()} {$childItem->getClass()}{/if}{if $childItem->isCurrent()} active{/if}"{if $childItem->getAttribute('dataToggleTab')} data-toggle="list" role="tab"{/if}{if $childItem->getAttribute('target')} target="{$childItem->getAttribute('target')}"{/if} id="{$childItem->getId()}">


### PR DESCRIPTION
On mobile and small tablet views, having d-inline-block causes the list to not extend to the full width of the card/panel.