### PR TITLE
Fix domain transferred away status label

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -10773,7 +10773,7 @@ fieldset[disabled] .btn-default.focus {
 }
 
 .status-expired,
-.status-transferred.away {
+.status-transferred-away {
   background-color: #004258;
 }
 


### PR DESCRIPTION
The domain transferred away status is 'transferred-away' but in this CSS file it's listed as two classes like: 'tarnsferred.away' -- this is wrong.