### PR TITLE
Do not show network issues alert in header when in shopping cart

### DIFF
--- a/header.tpl
+++ b/header.tpl
@@ -138,8 +138,10 @@
         </div>
     </header>
 
-    {include file="$template/includes/network-issues-notifications.tpl"}
-
+    {if !$inShoppingCart}
+        {include file="$template/includes/network-issues-notifications.tpl"}
+    {/if}
+    
     <nav class="master-breadcrumb" aria-label="breadcrumb">
         <div class="container">
             {include file="$template/includes/breadcrumb.tpl"}


### PR DESCRIPTION
This ensures those purchasing new services do not see your current issues, which is suboptimal for sales.