### PR TITLE
Ensure invoices show most recently due first, not oldest

### DIFF
--- a/clientareainvoices.tpl
+++ b/clientareainvoices.tpl
@@ -5,7 +5,7 @@
         var table = jQuery('#tableInvoicesList').show().DataTable();
 
         {if $orderby == 'default'}
-            table.order([4, 'desc'], [2, 'asc']);
+            table.order([4, 'desc'], [2, 'desc']);
         {elseif $orderby == 'invoicenum'}
             table.order(0, '{$sort}');
         {elseif $orderby == 'date'}


### PR DESCRIPTION
When a client has dozens of invoices, it doesn't make any sense to show the oldest ones first (after sorting by due date that is). This means that if all invoices are paid, it might show invoices from years ago rather than the most recent ones.

This change ensures that unpaid invoices are shown first, then the most recent invoices.