### PR TITLE
Rectify invalid conditional

### DIFF
--- a/homepage.tpl
+++ b/homepage.tpl
@@ -1,4 +1,4 @@
-{if !empty($productGroups) || $registerdomainenabled || $transferdomainenabled}
+{if !$productGroups->isEmpty() || $registerdomainenabled || $transferdomainenabled}
     <h2 class="text-center m-4">{lang key='clientHomePanels.productsAndServices'}</h2>
 
     <div class="card-columns home">


### PR DESCRIPTION
$productGroups will never evaluate to empty due to it being an Eloquent Collection. Even if empty, the object is still present.

This change ensures that the conditional evaluates the collection correctly using the `isEmpty` method to ensure that this conditional can be evaluated correctly.