### PR TITLE
Fix Iran (ir) flag background-position in Twenty-One template

### DIFF
--- a/css/all.css
+++ b/css/all.css
@@ -532,7 +532,7 @@
     background-position: -2457px 0px; }
   .iti-flag.ir {
     height: 12px;
-    background-position: -2479px 0px; }
+    background-position: -3131px 0px; }
   .iti-flag.is {
     height: 15px;
     background-position: -2501px 0px; }


### PR DESCRIPTION
Updated the CSS definition for the Iran flag in the Twenty-One theme to correct its displayed position.

Changed in css/all.css:

```
.iti-flag.ir {
    background-position: -3131px 0px;
}
```


This ensures the correct Iran flag appears in the intl-tel-input component.